### PR TITLE
Integrate npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ A simple tutorial for learning about electron.
 $ git clone git@github.com:justinmchase/electron-tutorial.git
 $ cd electron-tutorial
 $ npm install
-$ electron .
+$ npm start
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "electron main.js"
   },
   "author": "justin.m.chase@gmail.com",
   "license": "MIT",


### PR DESCRIPTION
Thank you for the great presentation at **TCCC19**, it was my favorite of the day. I shared your project with a few guys on my team who did not have electron-prebuilt installed globally, which causes the `electron .` command to not work even though it's a devDependency. Wiring this into the package.json's scripts section will fix this. Cheers!
